### PR TITLE
FIX required length for String in MySQL

### DIFF
--- a/state_machine/orm/sqlalchemy.py
+++ b/state_machine/orm/sqlalchemy.py
@@ -14,7 +14,7 @@ from state_machine.orm.base import BaseAdaptor
 
 class SqlAlchemyAdaptor(BaseAdaptor):
     def extra_class_members(self, initial_state):
-        return {'aasm_state': sqlalchemy.Column(sqlalchemy.String)}
+        return {'aasm_state': sqlalchemy.Column(sqlalchemy.String(256))}
 
     def update(self, document, state_name):
         document.aasm_state = state_name


### PR DESCRIPTION
SQLAlchemy requires a default length on String Columns if using MySQL.

This solves the error below that I was getting:

```
sqlalchemy.exc.CompileError: (in table 'export', column 'aasm_state'): VARCHAR requires a length on dialect mysql
```
