### PR TITLE
offer the possibility to change the name of the state field

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Basic Usage
 .. code:: python
 
 
-    @acts_as_state_machine
+    @acts_as_state_machine()
     class Person():
         name = 'Billy'
 
@@ -90,6 +90,14 @@ Blocks invalid state transitions
 An *InvalidStateTransition Exception* will be thrown if you try to move
 into an invalid state.
 
+Name of the state field
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The default name of the state field is "aasm_state". If you want to chane it, you just have to give it as  an argument to the acts_as_state_machine decorator:
+    @acts_as_state_machine('my_field_name')
+    class Person():
+		...
+
 ORM support
 -----------
 
@@ -106,7 +114,7 @@ datastore.
 
 .. code:: python
 
-        @acts_as_state_machine
+        @acts_as_state_machine()
         class Person(mongoengine.Document):
             name = mongoengine.StringField(default='Billy')
 
@@ -162,7 +170,7 @@ All you need to do is have sqlalchemy manage your object. For example:
 
         from sqlalchemy.ext.declarative import declarative_base
         Base = declarative_base()
-        @acts_as_state_machine
+        @acts_as_state_machine()
         class Puppy(Base):
            ...
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Basic Usage
 .. code:: python
 
 
-    @acts_as_state_machine
+    @acts_as_state_machine()
     class Person():
         name = 'Billy'
 
@@ -90,6 +90,14 @@ Blocks invalid state transitions
 An *InvalidStateTransition Exception* will be thrown if you try to move
 into an invalid state.
 
+Name of the state field
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The default name of the state field is "aasm_state". If you want to chane it, you just have to give it as  an argument to the acts_as_state_machine decorator:
+    @acts_as_state_machine('my_field_name')
+    class Person():
+		...
+
 ORM support
 -----------
 
@@ -106,7 +114,7 @@ datastore.
 
 .. code:: python
 
-        @acts_as_state_machine
+        @acts_as_state_machine()
         class Person(mongoengine.Document):
             name = mongoengine.StringField(default='Billy')
 
@@ -162,7 +170,7 @@ All you need to do is have sqlalchemy manage your object. For example:
 
         from sqlalchemy.ext.declarative import declarative_base
         Base = declarative_base()
-        @acts_as_state_machine
+        @acts_as_state_machine()
         class Puppy(Base):
            ...
 

--- a/state_machine/__init__.py
+++ b/state_machine/__init__.py
@@ -41,9 +41,11 @@ def after(after_what):
     return wrapper
 
 
-def acts_as_state_machine(original_class):
-    adaptor = get_adaptor(original_class)
-    global _temp_callback_cache
-    modified_class = adaptor.modifed_class(original_class, _temp_callback_cache)
-    _temp_callback_cache = None
-    return modified_class
+def acts_as_state_machine(state_field_name='aasm_state'):
+    def f(original_class):
+        adaptor = get_adaptor(original_class)
+        global _temp_callback_cache
+        modified_class = adaptor.modifed_class(original_class, _temp_callback_cache, state_field_name)
+        _temp_callback_cache = None
+        return modified_class
+    return f

--- a/state_machine/orm/__init__.py
+++ b/state_machine/orm/__init__.py
@@ -19,8 +19,9 @@ def get_adaptor(original_class):
 
 
 class NullAdaptor(BaseAdaptor):
-    def extra_class_members(self, initial_state):
-        return {"aasm_state": initial_state.name}
+    def extra_class_members(self, original_class, state_field_name, initial_state):
+        return {state_field_name: initial_state.name}
 
     def update(self, document, state_name):
-        document.aasm_state = state_name
+        setattr(document, document.__class__.state_field_name, state_name)
+        

--- a/state_machine/orm/mongoengine.py
+++ b/state_machine/orm/mongoengine.py
@@ -23,11 +23,12 @@ class MongoAdaptor(BaseAdaptor):
         return results
 
 
-    def extra_class_members(self, initial_state):
-        return {'aasm_state': mongoengine.StringField(default=initial_state.name)}
+
+    def extra_class_members(self, original_class, state_field_name, initial_state):
+        return {state_field_name: mongoengine.StringField(default=initial_state.name), 'id': original_class.pk}
 
     def update(self, document, state_name):
-        document.aasm_state = state_name
+        setattr(document, document.__class__.state_field_name, state_name)
 
 
 def get_mongo_adaptor(original_class):

--- a/tests.py
+++ b/tests.py
@@ -49,7 +49,48 @@ def requires_sqlalchemy(func):
 ###################################################################################
 
 def test_state_machine():
-    @acts_as_state_machine
+    @acts_as_state_machine()
+    class Robot():
+        name = 'R2-D2'
+
+        sleeping = State(initial=True)
+        running = State()
+        cleaning = State()
+
+        run = Event(from_states=sleeping, to_state=running)
+        cleanup = Event(from_states=running, to_state=cleaning)
+        sleep = Event(from_states=(running, cleaning), to_state=sleeping)
+
+        @before('sleep')
+        def do_one_thing(self):
+            print("{} is sleepy".format(self.name))
+
+        @before('sleep')
+        def do_another_thing(self):
+            print("{} is REALLY sleepy".format(self.name))
+
+        @after('sleep')
+        def snore(self):
+            print("Zzzzzzzzzzzz")
+
+        @after('sleep')
+        def snore(self):
+            print("Zzzzzzzzzzzzzzzzzzzzzz")
+
+
+    robot = Robot()
+    eq_(robot.current_state, 'sleeping')
+    assert robot.is_sleeping
+    assert not robot.is_running
+    robot.run()
+    assert robot.is_running
+    robot.sleep()
+    assert robot.is_sleeping
+
+
+
+def test_named_state_machine():
+    @acts_as_state_machine('state')
     class Robot():
         name = 'R2-D2'
 
@@ -89,7 +130,30 @@ def test_state_machine():
 
 
 def test_state_machine_no_callbacks():
-    @acts_as_state_machine
+    @acts_as_state_machine()
+    class Robot():
+        name = 'R2-D2'
+
+        sleeping = State(initial=True)
+        running = State()
+        cleaning = State()
+
+        run = Event(from_states=sleeping, to_state=running)
+        cleanup = Event(from_states=running, to_state=cleaning)
+        sleep = Event(from_states=(running, cleaning), to_state=sleeping)
+
+    robot = Robot()
+    eq_(robot.current_state, 'sleeping')
+    assert robot.is_sleeping
+    assert not robot.is_running
+    robot.run()
+    assert robot.is_running
+    robot.sleep()
+    assert robot.is_sleeping
+
+
+def test_named_state_machine_no_callbacks():
+    @acts_as_state_machine('state')
     class Robot():
         name = 'R2-D2'
 
@@ -112,7 +176,7 @@ def test_state_machine_no_callbacks():
 
 
 def test_multiple_machines():
-    @acts_as_state_machine
+    @acts_as_state_machine()
     class Person(object):
         sleeping = State(initial=True)
         running = State()
@@ -126,7 +190,44 @@ def test_multiple_machines():
         def on_run(self):
             things_done.append("Person.ran")
 
-    @acts_as_state_machine
+    @acts_as_state_machine()
+    class Dog(object):
+        sleeping = State(initial=True)
+        running = State()
+
+        run = Event(from_states=sleeping, to_state=running)
+        sleep = Event(from_states=(running,), to_state=sleeping)
+
+        @before('run')
+        def on_run(self):
+            things_done.append("Dog.ran")
+
+    things_done = []
+    person = Person()
+    dog = Dog()
+    eq_(person.current_state, 'sleeping')
+    eq_(dog.current_state, 'sleeping')
+    assert person.is_sleeping
+    assert dog.is_sleeping
+    person.run()
+    eq_(things_done, ["Person.ran"])
+
+def test_multiple_named_machines():
+    @acts_as_state_machine('state0')
+    class Person(object):
+        sleeping = State(initial=True)
+        running = State()
+        cleaning = State()
+
+        run = Event(from_states=sleeping, to_state=running)
+        cleanup = Event(from_states=running, to_state=cleaning)
+        sleep = Event(from_states=(running, cleaning), to_state=sleeping)
+
+        @before('run')
+        def on_run(self):
+            things_done.append("Person.ran")
+
+    @acts_as_state_machine('state1')
     class Dog(object):
         sleeping = State(initial=True)
         running = State()
@@ -158,9 +259,68 @@ def test_sqlalchemy_state_machine():
 
     Base = declarative_base()
 
-    @acts_as_state_machine
+    @acts_as_state_machine()
     class Puppy(Base):
         __tablename__ = 'puppies'
+        id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
+        name = sqlalchemy.Column(sqlalchemy.String)
+
+        sleeping = State(initial=True)
+        running = State()
+        cleaning = State()
+
+        run = Event(from_states=sleeping, to_state=running)
+        cleanup = Event(from_states=running, to_state=cleaning)
+        sleep = Event(from_states=(running, cleaning), to_state=sleeping)
+
+        @before('sleep')
+        def do_one_thing(self):
+            print("{} is sleepy".format(self.name))
+
+        @before('sleep')
+        def do_another_thing(self):
+            print("{} is REALLY sleepy".format(self.name))
+
+        @after('sleep')
+        def snore(self):
+            print("Zzzzzzzzzzzz")
+
+        @after('sleep')
+        def snore(self):
+            print("Zzzzzzzzzzzzzzzzzzzzzz")
+
+
+    Base.metadata.create_all(engine)
+
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    puppy = Puppy(name='Ralph')
+
+    eq_(puppy.current_state, Puppy.sleeping)
+    assert puppy.is_sleeping
+    assert not puppy.is_running
+    puppy.run()
+    assert puppy.is_running
+
+    session.add(puppy)
+    session.commit()
+
+    puppy2 = session.query(Puppy).filter_by(id=puppy.id)[0]
+
+    assert puppy2.is_running
+
+
+@requires_sqlalchemy
+def test_sqlalchemy_named_state_machine():
+    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.orm import sessionmaker
+
+    Base = declarative_base()
+
+    @acts_as_state_machine('state')
+    class Puppy(Base):
+        __tablename__ = 'named_puppies'
         id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
         name = sqlalchemy.Column(sqlalchemy.String)
 
@@ -219,9 +379,55 @@ def test_sqlalchemy_state_machine_no_callbacks():
 
     Base = declarative_base()
 
-    @acts_as_state_machine
+    @acts_as_state_machine()
     class Kitten(Base):
         __tablename__ = 'kittens'
+        id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
+        name = sqlalchemy.Column(sqlalchemy.String)
+
+        sleeping = State(initial=True)
+        running = State()
+        cleaning = State()
+
+        run = Event(from_states=sleeping, to_state=running)
+        cleanup = Event(from_states=running, to_state=cleaning)
+        sleep = Event(from_states=(running, cleaning), to_state=sleeping)
+
+
+    Base.metadata.create_all(engine)
+
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    kitten = Kitten(name='Kit-Kat')
+
+    eq_(kitten.current_state, Kitten.sleeping)
+    assert kitten.is_sleeping
+    assert not kitten.is_running
+    kitten.run()
+    assert kitten.is_running
+
+    session.add(kitten)
+    session.commit()
+
+    kitten2 = session.query(Kitten).filter_by(id=kitten.id)[0]
+
+    assert kitten2.is_running
+
+
+
+@requires_sqlalchemy
+def test_sqlalchemy_named_state_machine_no_callbacks():
+    ''' This is to make sure that the state change will still work even if no callbacks are registered.
+    '''
+    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.orm import sessionmaker
+
+    Base = declarative_base()
+
+    @acts_as_state_machine('state')
+    class Kitten(Base):
+        __tablename__ = 'named_kittens'
         id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
         name = sqlalchemy.Column(sqlalchemy.String)
 
@@ -264,9 +470,52 @@ def test_sqlalchemy_state_machine_using_initial_state():
 
     Base = declarative_base()
 
-    @acts_as_state_machine
+    @acts_as_state_machine()
     class Penguin(Base):
         __tablename__ = 'penguins'
+        id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
+        name = sqlalchemy.Column(sqlalchemy.String)
+
+        sleeping = State(initial=True)
+        running = State()
+        cleaning = State()
+
+        run = Event(from_states=sleeping, to_state=running)
+        cleanup = Event(from_states=running, to_state=cleaning)
+        sleep = Event(from_states=(running, cleaning), to_state=sleeping)
+
+
+    Base.metadata.create_all(engine)
+
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    # Note: No state transition occurs between the initial state and when it's saved to the database.
+    penguin = Penguin(name='Tux')
+    eq_(penguin.current_state, Penguin.sleeping)
+    assert penguin.is_sleeping
+
+    session.add(penguin)
+    session.commit()
+
+    penguin2 = session.query(Penguin).filter_by(id=penguin.id)[0]
+
+    assert penguin2.is_sleeping
+
+
+
+@requires_sqlalchemy
+def test_sqlalchemy_named_state_machine_using_initial_state():
+    ''' This is to make sure that the database will save the object with the initial state.
+    '''
+    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.orm import sessionmaker
+
+    Base = declarative_base()
+
+    @acts_as_state_machine('state')
+    class Penguin(Base):
+        __tablename__ = 'named_penguins'
         id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
         name = sqlalchemy.Column(sqlalchemy.String)
 
@@ -304,7 +553,7 @@ def test_sqlalchemy_state_machine_using_initial_state():
 @requires_mongoengine
 def test_mongoengine_state_machine():
 
-    @acts_as_state_machine
+    @acts_as_state_machine()
     class Person(mongoengine.Document):
         name = mongoengine.StringField(default='Billy')
 
@@ -352,7 +601,7 @@ def test_mongoengine_state_machine():
 
 @requires_mongoengine
 def test_invalid_state_transition():
-    @acts_as_state_machine
+    @acts_as_state_machine()
     class Person(mongoengine.Document):
         name = mongoengine.StringField(default='Billy')
 
@@ -376,7 +625,7 @@ def test_invalid_state_transition():
 
 @requires_mongoengine
 def test_before_callback_blocking_transition():
-    @acts_as_state_machine
+    @acts_as_state_machine()
     class Runner(mongoengine.Document):
         name = mongoengine.StringField(default='Billy')
 


### PR DESCRIPTION
offer the possibility to change the name of the state field.
It's needed for me 'cause I want to use a preexisting db model

(I also add a id alias to pk in mongo ORM)